### PR TITLE
EYZ-444 add api_name in related_modules

### DIFF
--- a/index.js
+++ b/index.js
@@ -402,6 +402,7 @@ class Zoho {
             if (!relatedModuleResult.error) {
                 result["related_modules"].push({
                     "module": relatedModule.module,
+                    "api_name": relatedModule.api_name,
                     "records": relatedModuleResult.records
                 });
             }
@@ -560,6 +561,7 @@ class Zoho {
             if (relatedModuleResult.statusCode == 200) {
                 result["related_modules"].push({
                     "module": relatedModule.module,
+                    "api_name": relatedModule.api_name,
                     "records": relatedModuleResult.records
                 });
             }

--- a/index.js
+++ b/index.js
@@ -328,7 +328,7 @@ class Zoho {
 
                 let response = await zoho.getRecords(params);
 
-                if (!response.records) hasMore = false;
+                if (!response.records.length) hasMore = false;
                 else {
                     let data = response.records;
 
@@ -495,7 +495,7 @@ class Zoho {
                 Object.assign(params, tempParams);
 
                 let response = await this.getRecords(params);
-                if (response.records) {
+                if (response.records && response.records.length) {
                     if (response.records.length > 0) resultData.push(...response.records);
                     else hasMore = false;
                 } else {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "zohoapi",
-  "version": "1.0.0",
+  "version": "1.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
please note: there is a bit of code duplication which is not done now because time limitation with zoho apis. I will do ASAP as a separate ticket.

duplication relates to the functions `getAllRecords` and `getRecordsModifiedAfter` where relatedmodules logic is there.